### PR TITLE
Add data folder URLs to runner summary

### DIFF
--- a/R/00_mainFunctions.R
+++ b/R/00_mainFunctions.R
@@ -131,6 +131,8 @@ runRegistryChecks <- function(.registry = "defaultRegistry"
                     ,.dataStoreUrl = .outputUrl
                     ,.resultsOfChecks = .checkOutput
                     ,.activeSites = .activeSites
+                    ,.dataFolderUrl = .prelimDataFolderUrl
+                    ,.lastMonthDataFolderUrl = .lastMonthDataFolderUrl
                     ,.cdmRomReportUrl = .cdmRomReportUrl
                     ,.lastMonthDataPullDate = .lastMonthDataPullDate
                     )

--- a/R/50_checkDataStore.R
+++ b/R/50_checkDataStore.R
@@ -5,6 +5,8 @@
 #' @param .dataStoreUrl A text url of the location where the check results will be stored
 #' @param .resultsOfChecks A list with the results of the data checks
 #' @param .activeSites Information on the list of active sites for this registry
+#' @param .dataFolderUrl Folder URL of the current month dataset
+#' @param .lastMonthDataFolderUrl Folder URL of the last month dataset
 #' @param .timestamp Timestamp that the checks were run
 #' @param .folderName Name for the folder where results will be output
 #' @param .cdmRomReportUrl (FOLDER URL) A url string to the location of the base CDM/ROM Report folder
@@ -18,6 +20,8 @@ submitToDataStore <- function(.registry
                               ,.dataStoreUrl
                               ,.resultsOfChecks
                               ,.activeSites
+                              ,.dataFolderUrl
+                              ,.lastMonthDataFolderUrl
                               ,.cdmRomReportUrl
                               ,.lastMonthDataPullDate
                               ){
@@ -39,6 +43,8 @@ submitToDataStore <- function(.registry
     ,"user" = Sys.info()[["user"]]
     ,"folderLoc" = .dataStoreUrl
     ,"pullDate" = .dsPullDate
+    ,"dataFolderUrl" = .dataFolderUrl
+    ,"lastMonthDataFolderUrl" = .lastMonthDataFolderUrl
   )
   
   # Generate a summary of the check results to output with the check results

--- a/man/submitToDataStore.Rd
+++ b/man/submitToDataStore.Rd
@@ -12,6 +12,8 @@ submitToDataStore(
   .dataStoreUrl,
   .resultsOfChecks,
   .activeSites,
+  .dataFolderUrl,
+  .lastMonthDataFolderUrl,
   .cdmRomReportUrl,
   .lastMonthDataPullDate
 )
@@ -30,6 +32,10 @@ submitToDataStore(
 \item{.resultsOfChecks}{A list with the results of the data checks}
 
 \item{.activeSites}{Information on the list of active sites for this registry}
+
+\item{.dataFolderUrl}{Folder URL of the current month dataset}
+
+\item{.lastMonthDataFolderUrl}{Folder URL of the last month dataset}
 
 \item{.cdmRomReportUrl}{(FOLDER URL) A url string to the location of the base CDM/ROM Report folder}
 


### PR DESCRIPTION
- Add last month and this month data folder URLs to runner summary to print in the runner summary in the HTML report

- Add new params to checkDataStore to read in and then display the data folder URLs

- Will update rdcrd code