### PR TITLE
Update CC6 error

### DIFF
--- a/R/26_checkForRemovedRows.R
+++ b/R/26_checkForRemovedRows.R
@@ -15,7 +15,7 @@ checkForRemovedRows <- function(.dsToCheck,.compDsToCheck,.uniqueKey){
   
   .tempDsToCheck <- .dsToCheck |>
     cleanUniqueKeyClasses(uniqueKeyVars = list(.uniqueKeys))
-  .tempCompDsToCheck <- .dsToCheck |>
+  .tempCompDsToCheck <- .compDsToCheck |>
     cleanUniqueKeyClasses(uniqueKeyVars = list(.uniqueKeys))
 
   # Create dataframe of rows in .compDsToCheck and not in .dsToCheck

--- a/RegistryDQChecks.Rproj
+++ b/RegistryDQChecks.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 9ff7aa33-f1a2-45f1-8dba-048ddc49dbef
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
Bug: When coding and testing data_check function I noticed that the output for the observations in last month and not in this month were not matching the CC6 output which also reports on this

Cause: Upon investigation, it was noted in the CC6 code that .dsToCheck was read in for both this month's and last month's dataset so the resulting comparison only ended up comparing this month to this month - which showed no removed observations

Remedy: Updated the second call to .dsToCheck to .compDsToCheck to appropriately read in and then compare last month to this month